### PR TITLE
only load the user script on supported sites

### DIFF
--- a/clip-studio-reader-downloader.js
+++ b/clip-studio-reader-downloader.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Clip Studio Reader Downloader
 // @namespace    http://tampermonkey.net/
-// @version      1.10
+// @version      1.11
 // @description  Download books from the browser version of Clip Studio Reader
 // @author       mrcoconuat
 // @supportURL   https://github.com/MrCocoNuat/clip-studio-reader-downloader/issues

--- a/clip-studio-reader-downloader.js
+++ b/clip-studio-reader-downloader.js
@@ -5,7 +5,12 @@
 // @description  Download books from the browser version of Clip Studio Reader
 // @author       mrcoconuat
 // @supportURL   https://github.com/MrCocoNuat/clip-studio-reader-downloader/issues
-// @match        *://*/*
+// @match        https://mbj-bs.pf.mobilebook.jp/*
+// @match        https://mbj-bs2.pf.mobilebook.jp/*
+// @match        https://api.distribution.mediadotech.com/*
+// @match        https://comic-viewer.iowl.jp/*
+// @match        https://comic.pixiv.net/*
+// @match        https://bs.comicdc.jp/*
 // @require      https://unpkg.com/jszip@3.10.1/dist/jszip.js
 // @require      https://unpkg.com/file-saver@2.0.5/dist/FileSaver.js
 // @icon         https://www.google.com/s2/favicons?sz=64&domain=mobilebook.jp


### PR DESCRIPTION
Since the user script only works on a limited number of sites, it seems a bit excessive to let it run on every domain.

I only tested this on honto, but I assume the other sites don't need anything outside the sites listed in the `siteSupport` object.  Feel free to scrap this if that isn't the case.